### PR TITLE
handle case where QT_API is set to lowercase pyqt5 or pyside2

### DIFF
--- a/asyncqt/__init__.py
+++ b/asyncqt/__init__.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    QtModuleName = os.environ['QT_API']
+    QtModuleName = {'pyqt5': 'PyQt5', 'pyside2': 'PySide2'}.get(os.environ['QT_API'].lower(), os.environ['QT_API'])
 except KeyError:
     QtModule = None
 else:


### PR DESCRIPTION
I encountered an issue where asyncqt imports would fail when using [qtpy](https://github.com/spyder-ide/qtpy). This is happening because the QT_API environment variable is being set to pyqt5, pyside2, etc, which aren't the importable module names.

It seems in general that QT_API can take the following values:
- pyqt5 (to use PyQt5).
- pyqt or pyqt4 (to use PyQt4).
- pyside2 (to use PySide2)
- pyside (to use PySide).

I modified it how QtModuleName is set from QT_API so it can handle lowercase pyqt5 and pyside2. Setting QT_API to 'PyQt5' or 'PySide2' still works as before.