### PR TITLE
Schedule timed calls as close as possible to the requested time.

### DIFF
--- a/asyncqt/__init__.py
+++ b/asyncqt/__init__.py
@@ -199,7 +199,7 @@ class _SimpleTimer(QtCore.QObject):
         self._stopped = False
 
     def add_callback(self, handle, delay=0):
-        timerid = self.startTimer(delay * 1000)
+        timerid = self.startTimer(delay * 1000, timerType=QtCore.Qt.PreciseTimer)
         self._logger.debug("Registering timer id {0}".format(timerid))
         assert timerid not in self.__callbacks
         self.__callbacks[timerid] = handle


### PR DESCRIPTION
By default, [`QObject.startTimer`](https://doc.qt.io/qtforpython/PySide2/QtCore/QObject.html#PySide2.QtCore.PySide2.QtCore.QObject.startTimer) uses `Qt.CoarseTimer`, which [the documentation](https://doc.qt.io/qt-5/qt.html#TimerType-enum) says tries to keep the time interval within 5% of the request.

It seems to me that it would be better to instruct Qt to use the most precise timer available, so that Qt runs timed calls as close as possible to when requested.

This change tells Qt to use `Qt.PreciseTimer` for timed calls, which aims to keep millisecond accuracy.