### PR TITLE
Optional argument to QEventLoop constructor for already running loops

### DIFF
--- a/asyncqt/__init__.py
+++ b/asyncqt/__init__.py
@@ -255,7 +255,7 @@ class _QEventLoop:
     ...     loop.run_until_complete(xplusy(2, 2))
     """
 
-    def __init__(self, app=None, set_running_loop=True):
+    def __init__(self, app=None, set_running_loop=True, already_running=False):
         self.__app = app or QApplication.instance()
         assert self.__app is not None, 'No QApplication has been instantiated'
         self.__is_running = False
@@ -275,6 +275,11 @@ class _QEventLoop:
 
         if set_running_loop:
             asyncio.events._set_running_loop(self)
+
+        # We have to set __is_running to True after calling
+        # super().__init__() because of a bug in BaseEventLoop.
+        if already_running:
+            self.__is_running = True
 
     def run_forever(self):
         """Run eventloop forever."""


### PR DESCRIPTION
In certain situations, Python is running in an environment where the event loop as already been started. For example when Python is embedded as a scripting language within another application. As such, when creating a QEventLoop, we need to be able to set __is_running to True. I added an optional argument to the constructor that lets us do this.

The value if __is_running is set only after the superclass's constructor is called, because I found a bug in asyncio's BaseEventLoop: an exception occurs during initialization if the event loop reports it is already running. I'll be submitting a patch for that to the asyncio maintainers. In the meantime, setting __is_running at the end of QEventLoop's constructor seems to work fine.