### PR TITLE
Follow the asyncio docs and do not quit run_forever() unless stop() is called.

### DIFF
--- a/asyncqt/__init__.py
+++ b/asyncqt/__init__.py
@@ -276,15 +276,19 @@ class _QEventLoop:
         if set_running_loop:
             asyncio.events._set_running_loop(self)
 
-    def run_forever(self):
+    def run_forever(self, respect_qt_exit=False):
         """Run eventloop forever."""
         self.__is_running = True
         self._before_run_forever()
 
         try:
             self._logger.debug('Starting Qt event loop')
-            rslt = self.__app.exec_()
-            self._logger.debug('Qt event loop ended with result {}'.format(rslt))
+            while True:
+                rslt = self.__app.exec_()
+                self._logger.debug('Qt event loop ended with result {}'.format(rslt))
+                if respect_qt_exit or not self.__is_running:
+                    break
+                self._logger.debug('Restarting Qt event loop: stop() was not called')
             return rslt
         finally:
             self._after_run_forever()


### PR DESCRIPTION
This may seem like a trivial thing, but I've come across a situation where a framework really gets confused if the asyncio main loop exits without `loop.stop()` having been called. At the moment this can happen if Qt itself triggers the quit (e.g., the last window is closed, or some other internal thing).

Thing change means that, if Qt tries to quit without `loop.stop()` having been called, it will just get started again. This means developers will have to make sure they handle the quit case, so that the app doesn't just continue silently in the background.